### PR TITLE
WIP: feature/isolate stories

### DIFF
--- a/examples/basic/components/Button.jsx
+++ b/examples/basic/components/Button.jsx
@@ -1,7 +1,16 @@
 import React from 'react'
+import styled from 'styled-components'
 
 const Button = ({ onClick, children }) => (
   <button onClick={onClick}>{children}</button>
 )
 
+const StyledButton = styled('button')`
+  appearance: none;
+  background: purple;
+  border: none;
+  color: white;
+`
+
 export default Button
+export { StyledButton }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -25,6 +25,7 @@
     "docz-plugin-storybook": "link:../..",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
-    "react-virtualized": "^9.21.0"
+    "react-virtualized": "^9.21.0",
+    "styled-components": "^4.0.3"
   }
 }

--- a/examples/basic/storybook/button-story.js
+++ b/examples/basic/storybook/button-story.js
@@ -1,13 +1,15 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import Button from '../components/Button'
+import Button, { StyledButton } from '../components/Button'
 
 storiesOf('Button', module)
   .add('with text', () => <Button>Hello Button</Button>)
   .add('with some emoji', () => (
     <Button>
+      <style>{'* { font-size: 24px; }'}</style>
       <span role={'img'} aria-label={'so cool'}>
         😀 😎 👍 💯
       </span>
     </Button>
   ))
+  .add('with styled components', () => <StyledButton>I'm styled!</StyledButton>)

--- a/examples/basic/yarn.lock
+++ b/examples/basic/yarn.lock
@@ -712,7 +712,7 @@
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
 
-"@emotion/is-prop-valid@^0.6.1":
+"@emotion/is-prop-valid@^0.6.1", "@emotion/is-prop-valid@^0.6.8":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
   dependencies:
@@ -1931,6 +1931,13 @@ babel-plugin-react-docgen@^2.0.0:
   dependencies:
     lodash "^4.17.10"
     react-docgen "^3.0.0-rc.1"
+
+"babel-plugin-styled-components@>= 1":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz#9dd054c8e86825203449a852a5746f29f2dab857"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    lodash "^4.17.10"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -3551,6 +3558,10 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -3610,6 +3621,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -4280,10 +4299,6 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-ensure-array@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ensure-array/-/ensure-array-1.0.0.tgz#317e9fc632c656bb849eb649133528e205b23abc"
-
 entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -4694,7 +4709,7 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -6587,6 +6602,10 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -8162,6 +8181,10 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -8232,6 +8255,10 @@ react-router@^4.3.1:
     path-to-regexp "^1.7.0"
     prop-types "^15.6.1"
     warning "^4.0.1"
+
+react-shadow@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-shadow/-/react-shadow-16.3.1.tgz#fcdb0e3d414cf09035d58156a895d11b57d3f19f"
 
 react-sizes@^1.0.4:
   version "1.0.4"
@@ -9411,6 +9438,20 @@ style-loader@^0.20.3:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
+styled-components@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.3.tgz#6c1a95a93857aa613fdfc26ad40899217100d8c3"
+  dependencies:
+    "@emotion/is-prop-valid" "^0.6.8"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
@@ -9435,7 +9476,7 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "babel-core": "7.0.0-bridge.0"
   },
   "dependencies": {
-    "docz-core": "^0.12.5"
+    "docz-core": "^0.12.5",
+    "react-shadow": "^16.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/src/react/Story.js
+++ b/src/react/Story.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ShadowDOM from 'react-shadow'
 
 import { _clientAPI } from '../shim'
 
@@ -10,29 +11,21 @@ export default class Story extends Component {
   }
 
   render() {
-    const {
-      kind,
-      name,
-      ...rest
-    } = this.props
+    const { kind, name, ...rest } = this.props
 
     const story = _clientAPI.store.getStoryWithContext(kind, name)
 
     if (!story) {
       console.error('unable to find story', { kind, name })
-      return (
-        <div />
-      )
+      return <div />
     }
 
     // TODO: should we show the kind or name?
 
     return (
-      <div
-        {...rest}
-      >
-        {story()}
-      </div>
+      <ShadowDOM>
+        <div {...rest}>{story()}</div>
+      </ShadowDOM>
     )
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7300,6 +7300,10 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
+react-shadow@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-shadow/-/react-shadow-16.3.1.tgz#fcdb0e3d414cf09035d58156a895d11b57d3f19f"
+
 react-test-renderer@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.0.tgz#fe490096bed55c3f4e92c023da3b89f9d03fceb3"


### PR DESCRIPTION
Wanted to create this PR as a starting point for discussion around story isolation, issue #2. 

This implements [react-shadow](https://github.com/Wildhoney/ReactShadow) which makes it easy to wrap our stories with the shadow DOM giving us the isolation we're looking for. An example story I've included implements a <style> tag adjacent to a span modifying the font size for every element and the result only affects that button because it was isolated by the shadow DOM wrapper. 

Where it gets tricky is implementing a [styled-component](https://github.com/styled-components/styled-components) where the styles get injected into the HEAD. The isolated button knows nothing about those classnames. There's been some discussion about how to go about fixing that with plugins and wrappers but before diving into those I wanted to push this up for visibility.