### PR TITLE
feature/story wrapper

### DIFF
--- a/examples/basic/components/Button.mdx
+++ b/examples/basic/components/Button.mdx
@@ -33,3 +33,7 @@ import { Story, Stories } from 'docz-plugin-storybook/dist/react'
 ## Stories
 
 <Stories kind='Button' />
+
+## Custom frame styles
+
+<Story kind='Button' name='with text' style={{ border: '2px solid red' }} />

--- a/examples/basic/doczrc.js
+++ b/examples/basic/doczrc.js
@@ -2,6 +2,8 @@ const { storybook } = require('docz-plugin-storybook')
 
 module.exports = {
   plugins: [
-    storybook()
+    storybook({
+      storyWrapper: require.resolve('./story-wrapper')
+    })
   ]
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -25,6 +25,7 @@
     "docz-plugin-storybook": "link:../..",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
+    "react-frame-component": "^4.0.2",
     "react-virtualized": "^9.21.0"
   }
 }

--- a/examples/basic/story-wrapper.js
+++ b/examples/basic/story-wrapper.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import Frame from 'react-frame-component'
+
+export default ({ children, style = {}, ...rest }) => {
+  return (
+    <Frame
+      style={{
+        width: 320,
+        display: 'block',
+        overflow: 'scroll',
+        border: 0,
+        ...style
+      }}
+      {...rest}
+    >
+      {children}
+    </Frame>
+  )
+}

--- a/examples/basic/yarn.lock
+++ b/examples/basic/yarn.lock
@@ -8108,6 +8108,10 @@ react-feather@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-1.1.4.tgz#d0143da95f9d52843cf13a553091573a7c617897"
 
+react-frame-component@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.0.2.tgz#408f137ab4ba14cd13a5844b86ac972903dda021"
+
 react-fuzzy@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.2.tgz#fc13bf6f0b785e5fefe908724efebec4935eaefe"

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,39 @@ This plugin performs its magic with a few key steps:
 5. In the case of manual rendering, whenever a `Story` or multiple `Stories` are rendered, these components look up the target stories in our shim's store and invoke their renderer which produces a normal React subtree.
 6. Profit!
 
+## But my stories don't look right...
+
+We have a solution for this. By passing in a wrapper to the storybook config we give you the option to render your story in isolation if you so choose. Here are the steps to render each story to an iframe.
+
+1. Create a story wrapper component.
+2. Pass in the path to the wrapper in the storybook config.
+
+```js
+// story-wrapper.js
+import Frame from 'react-frame-component'
+
+export default ({ children, style = {}, ...rest }) => (
+  <Frame
+    style={{
+      width: 320,
+      ...style
+    }}
+    {...rest}
+  >
+    {children}
+  </Frame>
+)
+```
+
+```js
+// doczrc.js
+import { storybook } from 'docz-plugin-storybook'
+
+export default {
+  plugins: [storybook({ storyWrapper: './story-wrapper' })]
+}
+```
+
 ## Status
 
 This module is stable but some Storybook addons and webpack customizations will take extra steps to get working from within Docz.
@@ -139,7 +172,7 @@ This module is stable but some Storybook addons and webpack customizations will 
 - [x] add docz webpack entry for loading stories client-side into our custom shim
 - [x] `Story` react component
 - [x] `Stories` react component
-- [ ] wrap `Story` in an iframe to mimic storybook environment as closely as possible
+- [x] wrap `Story` in an iframe to mimic storybook environment as closely as possible
 - [ ] ensure `Story` is rerendered if its story changes during hot reload
 - [x] support explicit / manual story rendering within docz mdx files
 - [ ] support implicit / automatic storybook rendering (plugin option to insert one virtual mdx entry for each story "kind")
@@ -149,6 +182,7 @@ This module is stable but some Storybook addons and webpack customizations will 
 - [ ] integration tests with various storybook fixtures
 - [ ] example projects that showcase the storybook to docz conversion
 - [ ] would like a way to add a docz anchor and link to Stories children so each Story `<h2>` is linked in the primary nav
+- [ ] add wrapper examples using styled-components and react-shadow
 
 ## Related
 

--- a/src/default-wrapper.js
+++ b/src/default-wrapper.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const defaultWrapper = ({ children, ...rest }) => (
+  <div {...rest}>{children}</div>
+)
+
+defaultWrapper.displayName = 'docz-plugin-storybook.defaultWrapper'
+
+export default defaultWrapper

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import paths from './paths'
 export const storybook = (opts = { }) => {
   const {
     // these options are intended to mimic the storybook cli options
-    configDir = paths.storybook.configDir
+    configDir = paths.storybook.configDir,
+    storyWrapper
   } = opts
 
   const storybookConfigPath = path.resolve(configDir, paths.storybook.config)
@@ -43,6 +44,9 @@ export const storybook = (opts = { }) => {
       config.resolve = config.resolve || {}
       config.resolve.alias = config.resolve.alias || {}
       config.resolve.alias['@storybook/react'] = path.resolve(__dirname, './shim')
+
+      // create a wrapper around each component for isolation and surface it as docz-plugin-storybook/wrapper
+      config.resolve.alias['docz-plugin-storybook/story-wrapper'] = require.resolve(storyWrapper || './default-wrapper')
 
       console.log('webpack')
       console.log('-'.repeat(80))

--- a/src/react/Story.js
+++ b/src/react/Story.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import StoryWrapper from 'docz-plugin-storybook/story-wrapper'
 
 import { _clientAPI } from '../shim'
 
@@ -26,13 +27,6 @@ export default class Story extends Component {
     }
 
     // TODO: should we show the kind or name?
-
-    return (
-      <div
-        {...rest}
-      >
-        {story()}
-      </div>
-    )
+    return <StoryWrapper {...rest}>{story()}</StoryWrapper>
   }
 }


### PR DESCRIPTION
This PR addresses issue #2 by extending the docz-plugin-storybook config to accept a story `wrapper`.

```js
// doczrc.js
import { storybook } from 'docz-plugin-storybook';

export default {
  plugins: [storybook({ wrapper: './story-wrapper' })]
};
```
 
- `wrapper` accepts a path to a component that will wrap each story
-  if no wrapper is passed we use a default wrapper
- basic docz example updated to wrap each story with an [iframe](https://github.com/ryanseddon/react-frame-component)
- included example with custom styles passed to wrapper

TODO: (recommend future iteration)
- figure out how to play nice with css-in-js libs when isolated 

NOTES:
- tested a styled-component and found that react-styled-frame didn't work :/
- error occurred from react-styled-frame hack of copying in document.head.innerHTML
- recreated react-styled-frame locally and was able to get it to render but styles were missing

A couple thoughts: 
- issue may be from may be from multiple instances of styled-components (warning in console - doubtful)
-- two instances of styled-components.browser.esm.js, //webpack & //webpack-internal 
- issue may be from StyleSheetManager not talking to FrameContextConsumer (likely)
-- tried creating a separate ref as a target for StyleSheetManager to no avail 