### PR TITLE
added ability to generate playgrounds for components from the story d…

### DIFF
--- a/src/default-stories-of-template.js
+++ b/src/default-stories-of-template.js
@@ -1,4 +1,39 @@
-export default ({ kind, stories }) => {
+const renderComponentPlayground = (component) => {
+  if (!component) return ''
+
+  const { children, ...defaultPlaygroundProps } = component.defaultPlaygroundProps || {}
+
+  const propString = Object.keys(defaultPlaygroundProps).map(key => {
+    return `${key}={${defaultPlaygroundProps[key]}}`
+  }).join(' ')
+
+  if (children) {
+    return `<Playground>
+  <${component.importName} ${propString}>
+    ${children}
+  </${component.importName}>
+</Playground>
+`
+  }
+
+  return `<Playground>
+  <${component.importName} ${propString} />
+</Playground>
+`
+}
+
+const renderComponentImports = (component) => {
+  if (!component) return ''
+
+  const imports = [
+    { importName: component.importName, importPath: component.importPath },
+    ...component.otherImports
+  ]
+
+  return imports.map(imp => `import ${imp.importName} from '${imp.importPath}'`).join('\n')
+}
+
+export default ({ kind, stories, component, defaultPlaygroundProps }) => {
   const routes = kind.split('/').map((p) => p.trim())
 
   let kindTitle = kind
@@ -16,8 +51,12 @@ ${menu ? `menu: ${menu}` : ''}
 ---
 
 import { Story } from 'docz-plugin-storybook/dist/react'
+import { Playground } from 'docz'
+${renderComponentImports(component)}
 
 # ${kind}
+
+${renderComponentPlayground(component, defaultPlaygroundProps)}
 
 ${stories.map(({ name }) => `
 ## ${name}

--- a/src/index.js
+++ b/src/index.js
@@ -76,11 +76,12 @@ export const storybook = (opts = { }) => {
 
         fs.ensureDirSync(paths.temp)
         stories.forEach((storyKind) => {
-          const { kind, stories } = storyKind
+          const { kind, stories, component } = storyKind
           const kindSlug = slugify(kind)
           const content = storiesOfTemplate({
             kind,
-            stories
+            stories,
+            component
           })
 
           const file = path.join(paths.temp, `${kindSlug}-storybook.mdx`)


### PR DESCRIPTION
I know the `temp-stories.js` file is eventually going away, but when it does hopefully this data structure can be moved to the story definitions.

There are issues getting the docz `Playground` to render outside of MDX files, so the easiest way to get that working is to add it to the generated MDX files.  If we go the React route with the `Stories` component then it will be trickier to get the playground to work correctly.